### PR TITLE
Add model download progress bars and cache controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,6 +75,12 @@
         text-align: center;
         margin-bottom: 1rem;
       }
+      .model-progress {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        margin: 0.25rem 0;
+      }
     </style>
   </head>
   <body>
@@ -87,6 +93,24 @@
       </div>
       <div id="modelProgress">
         <strong id="downloadProgressText">Descargando modelos... 0%</strong>
+        <div class="model-progress">
+          <span>Detector:</span>
+          <progress id="langProgress" value="0" max="100"></progress>
+          <span id="langPercent">0%</span>
+        </div>
+        <div class="model-progress">
+          <span>Traductor:</span>
+          <progress id="transProgress" value="0" max="100"></progress>
+          <span id="transPercent">0%</span>
+        </div>
+        <div class="model-progress">
+          <span>TTS:</span>
+          <progress id="ttsProgress" value="0" max="100"></progress>
+          <span id="ttsPercent">0%</span>
+        </div>
+        <div id="cacheInfo"></div>
+        <button id="redownloadBtn" style="display:none; margin-top:0.5rem;">Volver a descargar</button>
+        <button id="deleteBtn" style="display:none; margin-top:0.5rem;">Borrar modelos</button>
       </div>
       <!-- Sección para cada etapa -->
       <div id="stage-deteccion" class="stage">
@@ -115,18 +139,111 @@
       };
 
       function updateDownloadProgress() {
-        // Aseguramos que los valores sean numéricos
-        const ld = Number(progressMap.langDetector) || 0;
-        const tr = Number(progressMap.translator) || 0;
-        const ts = Number(progressMap.synthesizer) || 0;
-        const avg = Math.round(((ld + tr + ts) / 3) * 100);
+        const ld = Math.round((Number(progressMap.langDetector) || 0) * 100);
+        const tr = Math.round((Number(progressMap.translator) || 0) * 100);
+        const ts = Math.round((Number(progressMap.synthesizer) || 0) * 100);
+        langProgress.value = ld;
+        transProgress.value = tr;
+        ttsProgress.value = ts;
+        langPercent.textContent = ld + "%";
+        transPercent.textContent = tr + "%";
+        ttsPercent.textContent = ts + "%";
+        const avg = Math.round((ld + tr + ts) / 3);
         document.getElementById("downloadProgressText").textContent = "Descargando modelos... " + avg + "%";
       }
 
       // Crear el Web Worker
-      const worker = new Worker("worker.js", { type: "module" });
+      let worker;
       const speakButton = document.getElementById("speak");
       const textInput = document.getElementById("text");
+      const langProgress = document.getElementById("langProgress");
+      const transProgress = document.getElementById("transProgress");
+      const ttsProgress = document.getElementById("ttsProgress");
+      const langPercent = document.getElementById("langPercent");
+      const transPercent = document.getElementById("transPercent");
+      const ttsPercent = document.getElementById("ttsPercent");
+      const cacheInfo = document.getElementById("cacheInfo");
+      const redownloadBtn = document.getElementById("redownloadBtn");
+      const deleteBtn = document.getElementById("deleteBtn");
+
+      let initialUsage = 0;
+
+      async function estimateUsage() {
+        if (navigator.storage && navigator.storage.estimate) {
+          const { usage } = await navigator.storage.estimate();
+          return usage || 0;
+        }
+        return 0;
+      }
+
+      async function clearCaches() {
+        if (caches && caches.keys) {
+          const keys = await caches.keys();
+          for (const k of keys) await caches.delete(k);
+        }
+        if (indexedDB && indexedDB.databases) {
+          const dbs = await indexedDB.databases();
+          for (const db of dbs) if (db.name) indexedDB.deleteDatabase(db.name);
+        }
+      }
+
+      function initWorker() {
+        worker?.terminate();
+        worker = new Worker("worker.js", { type: "module" });
+
+        worker.onmessage = async (e) => {
+          const { type, data, translation, model, progress, detected, mapped, stage, status } = e.data;
+          if (type === "download-progress") {
+            progressMap[model] = progress;
+            updateDownloadProgress();
+          } else if (type === "loaded") {
+            const finalUsage = await estimateUsage();
+            const sizeMB = ((finalUsage - initialUsage) / (1024 * 1024)).toFixed(2);
+            cacheInfo.textContent = `Tama\u00f1o total: ${sizeMB} MB`;
+            localStorage.setItem("modelsCached", "true");
+            localStorage.setItem("modelsSize", sizeMB);
+            redownloadBtn.style.display = "inline-block";
+            deleteBtn.style.display = "inline-block";
+            speakButton.textContent = "Generar Voz";
+            speakButton.disabled = false;
+          } else if (type === "stage") {
+            if (stage === "deteccion") {
+              if (status === "in-progress") {
+                detectedStatus.innerHTML = '<span class="spinner"></span>Detectando idioma...';
+                detectedInfo.textContent = "";
+              } else if (status === "complete") {
+                detectedStatus.textContent = "Completado";
+                detectedInfo.textContent = `Idioma detectado: ${detected} (${mapped})`;
+              }
+            } else if (stage === "traduccion") {
+              if (status === "in-progress") {
+                translationStatus.innerHTML = '<span class="spinner"></span>Traduciendo...';
+                translationInfo.textContent = "";
+              } else if (status === "complete") {
+                translationStatus.textContent = "Completado";
+                translationInfo.textContent = translation;
+              }
+            } else if (stage === "audio") {
+              if (status === "in-progress") {
+                audioStatus.innerHTML = '<span class="spinner"></span>Generando audio...';
+                audioContainer.innerHTML = "";
+              } else if (status === "complete") {
+                audioStatus.textContent = "Completado";
+              }
+            }
+          } else if (type === "result") {
+            const wavBlob = new Blob([data], { type: "audio/wav" });
+            const audioUrl = URL.createObjectURL(wavBlob);
+            audioContainer.innerHTML = `<audio controls src="${audioUrl}" autoplay style="width: 100%;"></audio>`;
+            speakButton.disabled = false;
+            speakButton.textContent = "Generar Voz";
+          } else if (type === "error") {
+            alert("Error: " + data);
+            speakButton.disabled = false;
+            speakButton.textContent = "Generar Voz";
+          }
+        };
+      }
 
       // Elementos para cada etapa
       const detectedStatus = document.getElementById("detected-status");
@@ -137,60 +254,12 @@
       const audioContainer = document.getElementById("audio-container");
       const modelProgressDiv = document.getElementById("modelProgress");
 
-      worker.onmessage = (e) => {
-        const { type, data, translation, model, progress, detected, mapped, stage, status } = e.data;
-        if (type === "download-progress") {
-          progressMap[model] = progress;
-          updateDownloadProgress();
-        } else if (type === "loaded") {
-          modelProgressDiv.style.display = "none";
-          speakButton.textContent = "Generar Voz";
-          speakButton.disabled = false;
-        } else if (type === "stage") {
-          if (stage === "deteccion") {
-            if (status === "in-progress") {
-              detectedStatus.innerHTML = '<span class="spinner"></span>Detectando idioma...';
-              detectedInfo.textContent = "";
-            } else if (status === "complete") {
-              detectedStatus.textContent = "Completado";
-              detectedInfo.textContent = `Idioma detectado: ${detected} (${mapped})`;
-            }
-          } else if (stage === "traduccion") {
-            if (status === "in-progress") {
-              translationStatus.innerHTML = '<span class="spinner"></span>Traduciendo...';
-              translationInfo.textContent = "";
-            } else if (status === "complete") {
-              translationStatus.textContent = "Completado";
-              translationInfo.textContent = translation;
-            }
-          } else if (stage === "audio") {
-            if (status === "in-progress") {
-              audioStatus.innerHTML = '<span class="spinner"></span>Generando audio...';
-              audioContainer.innerHTML = "";
-            } else if (status === "complete") {
-              audioStatus.textContent = "Completado";
-            }
-          }
-        } else if (type === "result") {
-          const wavBlob = new Blob([data], { type: "audio/wav" });
-          const audioUrl = URL.createObjectURL(wavBlob);
-          audioContainer.innerHTML = `<audio controls src="${audioUrl}" autoplay style="width: 100%;"></audio>`;
-          speakButton.disabled = false;
-          speakButton.textContent = "Generar Voz";
-        } else if (type === "error") {
-          alert("Error: " + data);
-          speakButton.disabled = false;
-          speakButton.textContent = "Generar Voz";
-        }
-      };
-
       speakButton.addEventListener("click", () => {
         const text = textInput.value.trim();
         if (!text) {
           alert("Por favor, ingresa un texto.");
           return;
         }
-        // Reiniciamos las secciones de cada etapa
         detectedStatus.textContent = "Pendiente";
         detectedInfo.textContent = "";
         translationStatus.textContent = "Pendiente";
@@ -201,6 +270,42 @@
         speakButton.textContent = "Procesando...";
         worker.postMessage({ type: "speak", text });
       });
+
+      redownloadBtn.addEventListener("click", async () => {
+        redownloadBtn.disabled = true;
+        deleteBtn.disabled = true;
+        await clearCaches();
+        localStorage.removeItem("modelsCached");
+        localStorage.removeItem("modelsSize");
+        progressMap = { langDetector: 0, translator: 0, synthesizer: 0 };
+        updateDownloadProgress();
+        initialUsage = await estimateUsage();
+        initWorker();
+        redownloadBtn.disabled = false;
+        deleteBtn.disabled = false;
+      });
+
+      deleteBtn.addEventListener("click", async () => {
+        deleteBtn.disabled = true;
+        await clearCaches();
+        localStorage.removeItem("modelsCached");
+        localStorage.removeItem("modelsSize");
+        cacheInfo.textContent = "";
+        redownloadBtn.style.display = "inline-block";
+        deleteBtn.style.display = "none";
+        deleteBtn.disabled = false;
+      });
+
+      (async () => {
+        initialUsage = await estimateUsage();
+        if (localStorage.getItem("modelsCached") === "true") {
+          const sizeMB = localStorage.getItem("modelsSize") || "";
+          cacheInfo.textContent = `Tama\u00f1o total: ${sizeMB} MB`;
+          redownloadBtn.style.display = "inline-block";
+          deleteBtn.style.display = "inline-block";
+        }
+        initWorker();
+      })();
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- show progress per model download using three progress bars
- cache downloaded models and remember their total size
- allow re-downloading or clearing cached models

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861250446d4832ea4bfb7443b7af3c1